### PR TITLE
Use a print call to render the sample code for deployment

### DIFF
--- a/tutorials/notebooks/deep dive materializing features - final.ipynb
+++ b/tutorials/notebooks/deep dive materializing features - final.ipynb
@@ -3840,7 +3840,8 @@
    ],
    "source": [
     "# get a python template for consuming the feature serving API\n",
-    "deployment.get_online_serving_code(language=\"python\")"
+    "sample_code = deployment.get_online_serving_code(language=\"python\")\n",
+    "print(sample_code)"
    ]
   },
   {

--- a/tutorials/notebooks/quick start end-to-end workflow - final.ipynb
+++ b/tutorials/notebooks/quick start end-to-end workflow - final.ipynb
@@ -2573,7 +2573,8 @@
    ],
    "source": [
     "# get a python template for consuming the feature serving API\n",
-    "deployment.get_online_serving_code(language=\"python\")"
+    "sample_code = deployment.get_online_serving_code(language=\"python\")\n",
+    "print)sample_code)"
    ]
   },
   {

--- a/tutorials/notebooks/quick start feature engineering - final.ipynb
+++ b/tutorials/notebooks/quick start feature engineering - final.ipynb
@@ -2157,7 +2157,8 @@
    ],
    "source": [
     "# get a python template for consuming the feature serving API\n",
-    "deployment.get_online_serving_code(language=\"python\")"
+    "sample_code = deployment.get_online_serving_code(language=\"python\")\n",
+    "print(sample_code)"
    ]
   },
   {


### PR DESCRIPTION
On the google colab environment the code from the
get_online_serving_code call ends up mangled and cannot be copied into a new cell. Using a print() renders it correctly but less elegantly.