### PR TITLE
Use --no-warn-conflicts to hide spurious errors at install time

### DIFF
--- a/tutorials/notebooks/deep dive data modeling - final.ipynb
+++ b/tutorials/notebooks/deep dive data modeling - final.ipynb
@@ -57,7 +57,7 @@
     "import urllib.request\n",
     "\n",
     "# install featurebyte package and download supporting library\n",
-    "!pip install featurebyte\n",
+    "!pip install --no-warn-conflicts featurebyte\n",
     "urllib.request.urlretrieve(\"https://raw.githubusercontent.com/featurebyte/featurebyte-hosted-tutorials/main/tutorials/notebooks/prebuilt_catalogs.py\", \"prebuilt_catalogs.py\")"
    ]
   },

--- a/tutorials/notebooks/deep dive feature engineering - final.ipynb
+++ b/tutorials/notebooks/deep dive feature engineering - final.ipynb
@@ -60,7 +60,7 @@
     "import urllib.request\n",
     "\n",
     "# install featurebyte package and download supporting library\n",
-    "!pip install featurebyte\n",
+    "!pip install --no-warn-conflicts featurebyte\n",
     "urllib.request.urlretrieve(\"https://raw.githubusercontent.com/featurebyte/featurebyte-hosted-tutorials/main/tutorials/notebooks/prebuilt_catalogs.py\", \"prebuilt_catalogs.py\")"
    ]
   },

--- a/tutorials/notebooks/deep dive materializing features - final.ipynb
+++ b/tutorials/notebooks/deep dive materializing features - final.ipynb
@@ -53,7 +53,7 @@
     "import urllib.request\n",
     "\n",
     "# install featurebyte package and download supporting library\n",
-    "!pip install featurebyte\n",
+    "!pip install --no-warn-conflicts featurebyte\n",
     "urllib.request.urlretrieve(\"https://raw.githubusercontent.com/featurebyte/featurebyte-hosted-tutorials/main/tutorials/notebooks/prebuilt_catalogs.py\", \"prebuilt_catalogs.py\")"
    ]
   },

--- a/tutorials/notebooks/playground credit cards.ipynb
+++ b/tutorials/notebooks/playground credit cards.ipynb
@@ -32,7 +32,7 @@
     "import urllib.request\n",
     "\n",
     "# install featurebyte package and download supporting library\n",
-    "!pip install featurebyte\n",
+    "!pip install --no-warn-conflicts featurebyte\n",
     "urllib.request.urlretrieve(\"https://raw.githubusercontent.com/featurebyte/featurebyte-hosted-tutorials/main/tutorials/notebooks/prebuilt_catalogs.py\", \"prebuilt_catalogs.py\")"
    ]
   },

--- a/tutorials/notebooks/playground healthcare.ipynb
+++ b/tutorials/notebooks/playground healthcare.ipynb
@@ -32,7 +32,7 @@
     "import urllib.request\n",
     "\n",
     "# install featurebyte package and download supporting library\n",
-    "!pip install featurebyte\n",
+    "!pip install --no-warn-conflicts featurebyte\n",
     "urllib.request.urlretrieve(\"https://raw.githubusercontent.com/featurebyte/featurebyte-hosted-tutorials/main/tutorials/notebooks/prebuilt_catalogs.py\", \"prebuilt_catalogs.py\")"
    ]
   },

--- a/tutorials/notebooks/quick start end-to-end workflow - final.ipynb
+++ b/tutorials/notebooks/quick start end-to-end workflow - final.ipynb
@@ -162,7 +162,7 @@
     "import urllib.request\n",
     "\n",
     "# install featurebyte package and download supporting library\n",
-    "!pip install featurebyte\n",
+    "!pip install --no-warn-conflicts featurebyte\n",
     "urllib.request.urlretrieve(\"https://raw.githubusercontent.com/featurebyte/featurebyte-hosted-tutorials/main/tutorials/notebooks/prebuilt_catalogs.py\", \"prebuilt_catalogs.py\")"
    ]
   },

--- a/tutorials/notebooks/quick start feature engineering - final.ipynb
+++ b/tutorials/notebooks/quick start feature engineering - final.ipynb
@@ -55,7 +55,7 @@
     "import urllib.request\n",
     "\n",
     "# install featurebyte package and download supporting library\n",
-    "!pip install featurebyte\n",
+    "!pip install --no-warn-conflicts featurebyte\n",
     "urllib.request.urlretrieve(\"https://raw.githubusercontent.com/featurebyte/featurebyte-hosted-tutorials/main/tutorials/notebooks/prebuilt_catalogs.py\", \"prebuilt_catalogs.py\")"
    ]
   },

--- a/tutorials/notebooks/quick start feature management - final.ipynb
+++ b/tutorials/notebooks/quick start feature management - final.ipynb
@@ -51,7 +51,7 @@
     "import urllib.request\n",
     "\n",
     "# install featurebyte package and download supporting library\n",
-    "!pip install featurebyte\n",
+    "!pip install --no-warn-conflicts featurebyte\n",
     "urllib.request.urlretrieve(\"https://raw.githubusercontent.com/featurebyte/featurebyte-hosted-tutorials/main/tutorials/notebooks/prebuilt_catalogs.py\", \"prebuilt_catalogs.py\")"
    ]
   },

--- a/tutorials/notebooks/quick start model training - final.ipynb
+++ b/tutorials/notebooks/quick start model training - final.ipynb
@@ -43,7 +43,7 @@
     "import urllib.request\n",
     "\n",
     "# install featurebyte package and download supporting library\n",
-    "!pip install featurebyte\n",
+    "!pip install --no-warn-conflicts featurebyte\n",
     "urllib.request.urlretrieve(\"https://raw.githubusercontent.com/featurebyte/featurebyte-hosted-tutorials/main/tutorials/notebooks/prebuilt_catalogs.py\", \"prebuilt_catalogs.py\")"
    ]
   },

--- a/tutorials/notebooks/quick start reusing features - final.ipynb
+++ b/tutorials/notebooks/quick start reusing features - final.ipynb
@@ -52,7 +52,7 @@
     "import urllib.request\n",
     "\n",
     "# install featurebyte package and download supporting library\n",
-    "!pip install featurebyte\n",
+    "!pip install --no-warn-conflicts featurebyte\n",
     "urllib.request.urlretrieve(\"https://raw.githubusercontent.com/featurebyte/featurebyte-hosted-tutorials/main/tutorials/notebooks/prebuilt_catalogs.py\", \"prebuilt_catalogs.py\")"
    ]
   },


### PR DESCRIPTION
In the Google Colab enviroment some of the pre-installed packages confuse pip's dependency resolver and throw errors that do not impact the tutorial functionality.